### PR TITLE
Added configuration options to the middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,25 @@ const Koa = require('koa');
 const prometheus = require('koa-prometheus-exporter');
 const app = new Koa();
 
-app.use(prometheus.middleware);
+//middleware is a function that returns the middleware async function, this is so you can pass configuration settings into the middleware.
+app.use(prometheus.middleware({}));
 ```
 
+Options can be passed into the middlware. 
+
+```
+Name: path
+Type: String
+Desciption: overrides the path the middleware listens on.
+e.g. "/overriden_path_to_export_metrics_on
+```
+	
+```
+Name: headerBlacklist: 
+Type: Array
+Description: will block any access to the metrics path if the request has a header in this list
+e.g. ["x-forwarded-for"]
+```
 This intercepts the path /metrics and will export the default [prom-client](https://github.com/siimon/prom-client) metrics for nodejs, plus the additional gc stats via [node-prometheus-gc-stats](https://github.com/SimenB/node-prometheus-gc-stats)
 
 if you want to add additional metrics you can access the client in two ways.
@@ -36,8 +52,9 @@ const Koa = require('koa');
 const prometheus = require('koa-prometheus-exporter');
 const app = new Koa();
 
-app.use(prometheus.middleware);
+app.use(prometheus.middleware());
 app.use(async (ctx, next) => {
+   // bear in mind you need to gaurd against making a metric with the same name in the same registry, this will error upon a refresh.
 	const counter = ctx.state.prometheus.Counter('counter', 'counter');
 	counter.inc();
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@echo-health/koa-prometheus-exporter",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "src/index.js",
   "license": "MIT",
   "engines": {

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -1,40 +1,102 @@
 const prometheus = require('../index');
 
+test("Should block any request that isn't a GET", async () => {
+    expect.assertions(1);
+    try {
+        await prometheus.middleware()(
+            {
+                headers: {},
+                state: {},
+                path: '/metrics',
+                method: 'post',
+                throw: (code, message) => {
+                    throw new Error(message);
+                },
+            },
+            null
+        );
+    } catch (err) {
+        expect(err.message).toBe('Method not allowed');
+    }
+});
+
 test('Should allow direct connections', () => {
     const next = jest.fn();
-    prometheus.middleware({
-        headers: {},
-        state: {},
-    }, next);
+    prometheus.middleware()(
+        {
+            headers: {},
+            state: {},
+        },
+        next
+    );
     expect(next.mock.calls.length).toBe(1);
 });
 
-test('Should allow direct connections to /metrics', () => {
+test('Should return metrics for overriden path', async () => {
     const next = jest.fn();
     const vals = {};
-    prometheus.middleware({
-        headers: {},
-        state: {},
-        path: "/metrics",
-        set: (key, value) => {
-           vals[key] = value;
-        }
-    }, next);
-    expect(next.mock.calls.length).toBe(1);
-    expect(Object.keys(vals).includes('Content-Type'));
+    const path = '/test';
+    await prometheus.middleware({
+        path,
+    })(
+        {
+            path,
+            headers: {},
+            state: {},
+            method: 'get',
+            set: (key, value) => {
+                vals[key] = value;
+            },
+        },
+        next
+    );
+    expect(next.mock.calls.length).toBe(0);
+    expect(Object.keys(vals).includes('Content-Type')).toBe(true);
     expect(vals['Content-Type']).toBeDefined();
 });
 
-test('Should deny direct connections to /metrics with x-forwarded-header', () => {
+test('Should return metrics for default path /metrics', async () => {
     const next = jest.fn();
-    expect(prometheus.middleware({
-        state: {},
-        headers: {
-            "x-forwarded-for": "192.168.0.1",
+    const vals = {};
+    await prometheus.middleware()(
+        {
+            headers: {},
+            state: {},
+            method: 'get',
+            path: '/metrics',
+            set: (key, value) => {
+                vals[key] = value;
+            },
         },
-        path: "/metrics",
-        throw: (code, message) => {
-            throw new Error(message)
-        },
-    }, next)).rejects.toBeInstanceOf(Error);
+        next
+    );
+    expect(next.mock.calls.length).toBe(0);
+    expect(Object.keys(vals).includes('Content-Type')).toBe(true);
+    expect(vals['Content-Type']).toBeDefined();
+});
+
+test('Should deny direct connections to /metrics with blacklisted header', async () => {
+    const next = jest.fn();
+    const header = 'x-forwarded-for';
+    expect.assertions(1);
+    try {
+        await prometheus.middleware({
+            headerBlacklist: [header],
+        })(
+            {
+                state: {},
+                method: 'get',
+                headers: {
+                    [header]: '192.168.0.1',
+                },
+                path: '/metrics',
+                throw: (code, message) => {
+                    throw new Error(message);
+                },
+            },
+            next
+        );
+    } catch (err) {
+        expect(err.message).toBe('Forbidden');
+    }
 });

--- a/src/index.js
+++ b/src/index.js
@@ -6,17 +6,30 @@ client.collectDefaultMetrics();
 
 module.exports = {
     client,
-    middleware: async (ctx, next) => {
-        ctx.state.prometheus = client;
-        if (ctx.path === '/metrics') {
-            debug('GET /metrics');
-            if (!ctx.headers["x-forwarded-for"]) {
-                ctx.set('Content-Type', client.register.contentType);
-                ctx.body = client.register.metrics();
+    middleware: (options = {}) => {
+        const path = options.path || '/metrics';
+        const { headerBlacklist } = options;
+        return async (ctx, next) => {
+            ctx.state.prometheus = client;
+            if (ctx.path === path) {
+                if (ctx.method.toLowerCase() === 'get') {
+                    debug('GET /%s', path);
+                    if (
+                        !headerBlacklist ||
+                        headerBlacklist.filter(h => {
+                            return Object.keys(ctx.headers).includes(h);
+                        }).length === 0
+                    ) {
+                        ctx.set('Content-Type', client.register.contentType);
+                        ctx.body = client.register.metrics();
+                        return null;
+                    }
+                    ctx.throw(403, 'Forbidden');
+                }
+                ctx.throw(405, 'Method not allowed');
             } else {
-                ctx.throw(403, "Forbidden");
+                await next();
             }
-        }
-        await next();
+        };
     },
 };


### PR DESCRIPTION
You can now override the metrics path, and add blacklisted headers to
block request on.