### PR TITLE
Add HTTP timing metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,4 +43,23 @@ app.use(async (ctx, next) => {
 })
 ```
 
+##Tracking HTTP Metrics
 
+If you would like to track HTTP metrics you can add an additional piece of middleware via.
+
+```
+const Koa = require('koa');
+const prometheus = require('koa-prometheus-exporter');
+const httpMetrics = prometheus.httpMetricMiddleware;
+const app = new Koa();
+
+// this has to be before any other middleware if you want accurate timing of request duration.
+app.use(httpMetrics);
+app.use(prometheus.middleware);
+```
+
+This exposes a prometheus Histogram metric called `http_request_duration_ms` which has the following bucket settings.
+
+`[0.1, 5, 15, 50, 100, 200, 300, 400, 500]`
+
+These are thresholds to collect on based on time in milliseconds. This will allow you to set thresholds to alarm on via the alert manager.

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -2,24 +2,30 @@ const prometheus = require('../index');
 
 test('Should allow direct connections', () => {
     const next = jest.fn();
-    prometheus.middleware({
-        headers: {},
-        state: {},
-    }, next);
+    prometheus.middleware(
+        {
+            headers: {},
+            state: {},
+        },
+        next
+    );
     expect(next.mock.calls.length).toBe(1);
 });
 
 test('Should allow direct connections to /metrics', () => {
     const next = jest.fn();
     const vals = {};
-    prometheus.middleware({
-        headers: {},
-        state: {},
-        path: "/metrics",
-        set: (key, value) => {
-           vals[key] = value;
-        }
-    }, next);
+    prometheus.middleware(
+        {
+            headers: {},
+            state: {},
+            path: '/metrics',
+            set: (key, value) => {
+                vals[key] = value;
+            },
+        },
+        next
+    );
     expect(next.mock.calls.length).toBe(1);
     expect(Object.keys(vals).includes('Content-Type'));
     expect(vals['Content-Type']).toBeDefined();
@@ -27,14 +33,45 @@ test('Should allow direct connections to /metrics', () => {
 
 test('Should deny direct connections to /metrics with x-forwarded-header', () => {
     const next = jest.fn();
-    expect(prometheus.middleware({
-        state: {},
-        headers: {
-            "x-forwarded-for": "192.168.0.1",
+    expect(
+        prometheus.middleware(
+            {
+                state: {},
+                headers: {
+                    'x-forwarded-for': '192.168.0.1',
+                },
+                path: '/metrics',
+                throw: (code, message) => {
+                    throw new Error(message);
+                },
+            },
+            next
+        )
+    ).rejects.toBeInstanceOf(Error);
+});
+
+test('Should track HTTP metrics as a Prometheus histogram', async () => {
+    const next = jest.fn();
+    const path = '/test';
+    await prometheus.httpMetricMiddleware(
+        {
+            request: {
+                path,
+                method: 'get',
+            },
+            response: {
+                status: 200,
+            },
+            state: {},
+            path,
         },
-        path: "/metrics",
-        throw: (code, message) => {
-            throw new Error(message)
-        },
-    }, next)).rejects.toBeInstanceOf(Error);
+        next
+    );
+    const metric = prometheus.client.register.getSingleMetric(
+        'http_request_duration_ms'
+    );
+    const metrics = Object.keys(metric.hashMap);
+    expect(metric).toBeInstanceOf(prometheus.client.Histogram);
+    expect(metrics.length).toBe(1);
+    expect(metrics[0]).toBe('code:200,method:get,route:/test');
 });

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,13 @@ const debug = require('debug')('prometheus:middleware');
 require('prometheus-gc-stats')(client.register)();
 
 client.collectDefaultMetrics();
+// setup metrics.
+const httpRequestDurationMicroseconds = new client.Histogram({
+    name: 'http_request_duration_ms',
+    help: 'Duration of HTTP requests in ms',
+    labelNames: ['method', 'route', 'code'],
+    buckets: [0.1, 5, 15, 50, 100, 200, 300, 400, 500],
+});
 
 module.exports = {
     client,
@@ -10,13 +17,20 @@ module.exports = {
         ctx.state.prometheus = client;
         if (ctx.path === '/metrics') {
             debug('GET /metrics');
-            if (!ctx.headers["x-forwarded-for"]) {
+            if (!ctx.headers['x-forwarded-for']) {
                 ctx.set('Content-Type', client.register.contentType);
                 ctx.body = client.register.metrics();
             } else {
-                ctx.throw(403, "Forbidden");
+                ctx.throw(403, 'Forbidden');
             }
         }
         await next();
+    },
+    httpMetricMiddleware: async (ctx, next) => {
+        const startEpoch = Date.now();
+        await next();
+        httpRequestDurationMicroseconds
+            .labels(ctx.request.method, ctx.request.path, ctx.response.status)
+            .observe(Date.now() - startEpoch);
     },
 };


### PR DESCRIPTION
Creates a prometheus Histogram metric to collect timing information on
the request and also the method/status code returned to the user.

This sets up some defaults rules based on the histogram bucket.
Presently this isn't configurable. The metric is added to the default
register for prom-client and will be exported with the default metrics
middleware.