### PR TITLE
Add HTTP timing metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,16 @@
 
 Requires koa to run
 
-Using npm:
+Using npm
 
 ```
-$ npm install @echo-health/koa-prometheus-exporter
+npm install @echo-health/koa-prometheus-exporter
 ```
 
-Using yarn:
+Using yarn
 
 ```
-$ yarn add @echo-health/koa-prometheus-exporter
+yarn add @echo-health/koa-prometheus-exporter
 ```
 
 To use the prometheus middlware the module exports a async middleware function called `middleware`
@@ -26,25 +26,27 @@ const Koa = require('koa');
 const prometheus = require('koa-prometheus-exporter');
 const app = new Koa();
 
-//middleware is a function that returns the middleware async function, this is so you can pass configuration settings into the middleware.
+// middleware is a function that returns the middleware async 
+// function, this is so you can pass configuration settings into
+// the middleware.
 app.use(prometheus.middleware({}));
 ```
 
-Options can be passed into the middlware. 
+Options can be passed into the middlware.
 
 ```
 Name: path
 Type: String
 Desciption: overrides the path the middleware listens on.
 e.g. "/overriden_path_to_export_metrics_on
-```
-	
-```
+
 Name: headerBlacklist: 
 Type: Array
-Description: will block any access to the metrics path if the request has a header in this list
+Description: will block any access to the metrics path if the
+request has a header in this list
 e.g. ["x-forwarded-for"]
 ```
+
 This intercepts the path /metrics and will export the default [prom-client](https://github.com/siimon/prom-client) metrics for nodejs, plus the additional gc stats via [node-prometheus-gc-stats](https://github.com/SimenB/node-prometheus-gc-stats)
 
 if you want to add additional metrics you can access the client in two ways.
@@ -62,10 +64,28 @@ const app = new Koa();
 
 app.use(prometheus.middleware());
 app.use(async (ctx, next) => {
-   // bear in mind you need to gaurd against making a metric with the same name in the same registry, this will error upon a refresh.
 	const counter = ctx.state.prometheus.Counter('counter', 'counter');
 	counter.inc();
 })
 ```
 
+##Tracking HTTP Metrics
 
+If you would like to track HTTP metrics you can add an additional piece of middleware via.
+
+```
+const Koa = require('koa');
+const prometheus = require('koa-prometheus-exporter');
+const httpMetrics = prometheus.httpMetricMiddleware;
+const app = new Koa();
+
+// this has to be before any other middleware if you want accurate timing of request duration.
+app.use(httpMetrics);
+app.use(prometheus.middleware());
+```
+
+This exposes a prometheus Histogram metric called `http_request_duration_ms` which has the following bucket settings.
+
+`[0.1, 5, 15, 50, 100, 200, 300, 400, 500]`
+
+These are thresholds to collect on based on time in milliseconds. This will allow you to set thresholds to alarm on via the alert manager.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@echo-health/koa-prometheus-exporter",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "main": "src/index.js",
   "license": "MIT",
   "engines": {

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,13 @@ const debug = require('debug')('prometheus:middleware');
 require('prometheus-gc-stats')(client.register)();
 
 client.collectDefaultMetrics();
+// setup metrics.
+const httpRequestDurationMicroseconds = new client.Histogram({
+    name: 'http_request_duration_ms',
+    help: 'Duration of HTTP requests in ms',
+    labelNames: ['method', 'route', 'code'],
+    buckets: [0.1, 5, 15, 50, 100, 200, 300, 400, 500],
+});
 
 module.exports = {
     client,
@@ -31,5 +38,12 @@ module.exports = {
                 await next();
             }
         };
+    },
+    httpMetricMiddleware: async (ctx, next) => {
+        const startEpoch = Date.now();
+        await next();
+        httpRequestDurationMicroseconds
+            .labels(ctx.request.method, ctx.request.path, ctx.response.status)
+            .observe(Date.now() - startEpoch);
     },
 };


### PR DESCRIPTION
Creates a prometheus Histogram metric to collect timing information on
the request and also the method/status code returned to the user.

This sets up some defaults rules based on the histogram bucket.
Presently this isn't configurable. The metric is added to the default
register for prom-client and will be exported with the default metrics
middleware.