### PR TITLE
Add defence for unset content-length header

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@echo-health/koa-prometheus-exporter",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "main": "src/index.js",
   "license": "MIT",
   "engines": {

--- a/src/index.js
+++ b/src/index.js
@@ -65,15 +65,27 @@ module.exports = {
     httpMetricMiddleware: async (ctx, next) => {
         const startEpoch = getMicroseconds();
         await next();
-        httpRequestSizeBytes
-            .labels(ctx.request.method, ctx.request.path, ctx.response.status)
-            .observe(ctx.request.length);
+        if (ctx.request.length) {
+            httpRequestSizeBytes
+                .labels(
+                    ctx.request.method,
+                    ctx.request.path,
+                    ctx.response.status
+                )
+                .observe(ctx.request.length);
+        }
+        if (ctx.response.length) {
+            httpResponseSizeBytes
+                .labels(
+                    ctx.request.method,
+                    ctx.request.path,
+                    ctx.response.status
+                )
+                .observe(ctx.response.length);
+        }
         httpRequestDurationMicroseconds
             .labels(ctx.request.method, ctx.request.path, ctx.response.status)
             .observe(getMicroseconds() - startEpoch);
-        httpResponseSizeBytes
-            .labels(ctx.request.method, ctx.request.path, ctx.response.status)
-            .observe(ctx.response.length);
         httpRequestsTotal
             .labels(ctx.request.method, ctx.request.path, ctx.response.status)
             .inc();


### PR DESCRIPTION
The Koa request object may have an undefined value for length.